### PR TITLE
Fix/browser language

### DIFF
--- a/src/Geta.EPi.GeolocationTools/Services/GeolocationService.cs
+++ b/src/Geta.EPi.GeolocationTools/Services/GeolocationService.cs
@@ -163,7 +163,7 @@ namespace Geta.EPi.GeolocationTools.Services
 
         private Func<LanguageBranch, bool> IsLanguageBranchForBrowserLanguage(IEnumerable<string> location)
         {
-            return x => location.Any(l => l.Equals(x.Name, StringComparison.InvariantCultureIgnoreCase));
+            return x => location.Any(l => l.Equals(x.Culture.Name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private LanguageBranch GetFallbackLanguageBranch()


### PR DESCRIPTION
Using culture's name (for example, en) instead of language branch name (for example, English) because the location list contain culture names.